### PR TITLE
Configured session starts to automatically close after being read, in…

### DIFF
--- a/inc/jp-facebook-album.php
+++ b/inc/jp-facebook-album.php
@@ -16,7 +16,7 @@ class JpFacebookAlbum {
         // We use the session to hold the 'FBRLH_state' key, and it gets
         // compared upon return to the callback page to prevent CSRF attacks.
         if ( !session_id() ) {
-            session_start();
+            session_start( array( 'read_and_close' => true ) );
         }
 
         $this->CALLBACK_URL = get_site_url() . '/wp-admin/options-general.php?page=facebook-album';
@@ -168,7 +168,7 @@ class JpFacebookAlbum {
         // Session is necessary for initial authorization, as we leave
         // the site for Facebook, then come back via redirect URI
         if ( ! session_id() ) {
-            session_start();
+            session_start( array( 'read_and_close' => true ) );
         }
 
         $fb = new Facebook\Facebook([

--- a/jp-facebook-album.php
+++ b/jp-facebook-album.php
@@ -3,7 +3,7 @@
  * Plugin Name: JP Facebook Album
  * Plugin URI: https://github.com/jasonpau/jp-facebook-album/
  * Description: A simple plugin that adds a basic WP admin interface for authenticating with Facebook's Graph API
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: Jason Pau
  * Author URI: https://jasonpau.io
  */


### PR DESCRIPTION
… order to prevent a WP error.

See this blog post for more information on the error: https://markohoven.com/2020/06/03/wordpress-site-health-the-rest-api-encountered-an-error/